### PR TITLE
Allow `False` and nonintegral zeros in `validator.required`

### DIFF
--- a/strainer/validators.py
+++ b/strainer/validators.py
@@ -7,8 +7,8 @@ Validators are functions that validate data.
 """
 import iso8601
 
-from functools import partial, wraps
 from .exceptions import ValidationException
+from functools import partial, wraps
 from six import text_type
 
 
@@ -59,13 +59,13 @@ def string(value, max_length=None, context=None):
 @export_validator
 def required(value, context=None):
     """validates that a field exists in the input"""
-    if value is 0:
+    if value:
         return value
 
-    if not value:
-        raise ValidationException('This field is required')
+    if value == 0:
+        return value
 
-    return value
+    raise ValidationException('This field is required')
 
 
 @export_validator

--- a/tests/test_validators.py
+++ b/tests/test_validators.py
@@ -44,7 +44,10 @@ def test_required():
     with pytest.raises(ValidationException):
         validator('')
 
-    assert validator(0) == 0
+    assert validator(False) is False
+
+    for zero in [0, 0.0, 0j]:
+        assert validator(zero) == zero
 
 
 def test_boolean():


### PR DESCRIPTION
This commit cleans up `validator.required`'s handling of falsey values.

Notably, it keeps the validator from getting tripped up when the
consumer passes in `False` or `0.0`.  It also reorganizes the guards
so we return immediately when a value is present.